### PR TITLE
Add optimized Airflow Alpine image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.github
+helm
+k8s
+docs
+tests

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ Custom Apache Airflow deployment with Alpine-based Docker images for Kubernetes 
 - **docs/** – Project documentation
 - **tests/** – Test cases and utilities
 
+## Docker Image
+
+The `docker/Dockerfile` builds a lightweight Airflow image based on
+Alpine Linux 3.19. Build it locally with:
+
+```bash
+docker build -t airflow-alpine -f docker/Dockerfile .
+```
+
 ## CI/CD
 
 A GitHub Actions workflow builds and pushes a Docker image on every push or pull request to the `main` branch. Docker registry credentials are provided via repository secrets:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1
+ARG PYTHON_VERSION=3.11
+ARG AIRFLOW_VERSION=2.8.1
+ARG ALPINE_VERSION=3.19
+
+FROM python:${PYTHON_VERSION}-alpine${ALPINE_VERSION} AS builder
+ARG AIRFLOW_VERSION
+ARG PYTHON_VERSION
+
+ENV PIP_NO_CACHE_DIR=1
+
+# Install build dependencies
+RUN apk add --no-cache --virtual .build-deps \
+        gcc musl-dev libc-dev libffi-dev openssl-dev cargo make postgresql-dev \
+    && pip install --upgrade pip \
+    && pip install "apache-airflow==${AIRFLOW_VERSION}" \
+         --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt" \
+    && apk del .build-deps
+
+FROM python:${PYTHON_VERSION}-alpine${ALPINE_VERSION}
+ARG AIRFLOW_VERSION
+ARG PYTHON_VERSION
+ENV AIRFLOW_HOME=/opt/airflow \
+    PATH=/usr/local/bin:$PATH
+
+# Runtime dependencies and user setup
+RUN apk add --no-cache bash postgresql-client redis su-exec \
+    && addgroup -S airflow && adduser -S -G airflow airflow \
+    && mkdir -p ${AIRFLOW_HOME} \
+    && chown airflow:airflow ${AIRFLOW_HOME}
+
+COPY --from=builder /usr/local /usr/local
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+USER airflow
+WORKDIR ${AIRFLOW_HOME}
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["airflow", "webserver"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+# Drop privileges if running as root
+if [ "$(id -u)" = "0" ]; then
+    exec su-exec airflow "$@"
+else
+    exec "$@"
+fi


### PR DESCRIPTION
## Summary
- add `.dockerignore`
- create a multi-stage Dockerfile based on Alpine 3.19
- include entrypoint script for running as non-root
- document how to build the image

## Testing
- `shellcheck docker/entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_68834f8376a4832ca112a0f07eb4ca5f