### PR TITLE
Update Helm docs and ignore built chart files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,10 @@ __pycache__/
 # Misc
 .DS_Store
 
+# Helm
+helm/airflow/docs/
+helm/airflow/values.schema.json
+helm/airflow/values.yaml
+helm/airflow/charts/postgresql/
+helm/airflow/charts/postgresql-*.tgz
+

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Alpine Linux 3.19. Build it locally with:
 docker build -t airflow-alpine -f docker/Dockerfile .
 ```
 
+## Helm Chart
+
+The `helm/airflow` chart depends on Bitnami subcharts. Only `Chart.yaml` and the
+optional `Chart.lock` are kept in version control. Run the following command to
+download dependencies before deploying:
+
+```bash
+helm dependency build helm/airflow
+```
+
 ## CI/CD
 
 A GitHub Actions workflow builds and pushes a Docker image on every push or pull request to the `main` branch. Docker registry credentials are provided via repository secrets:


### PR DESCRIPTION
## Summary
- ignore Helm chart artifacts so only `Chart.yaml` and `Chart.lock` remain
- document fetching Helm dependencies via `helm dependency build`

## Testing
- `./tests/test_hadolint.sh`
- `./tests/test_trivy.sh`
- `./tests/test_packages.sh`


------
https://chatgpt.com/codex/tasks/task_e_68835b8456a8832cb39e10e9c0579af6