### PR TITLE
Add ArgoCD application manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ helm/charts/
 # Kubernetes
 *.yaml
 !helm/*.yaml
+!k8s/**/*.yaml
 
 # Misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -71,3 +71,13 @@ Run the integration test (requires `kind`, `kubectl` and `helm` in your PATH):
 ```bash
 ./tests/test_k8s_integration.sh
 ```
+
+## ArgoCD Deployment
+
+Manifests for ArgoCD are available under `k8s/argocd`. The base configuration
+creates an `Application` that syncs this repository's Helm chart. Environment
+overlays for `dev`, `staging` and `prod` adjust the target namespace and Git
+branch. The sync policy enables automatic deployment, pruning and self-healing.
+
+See [docs/argocd.md](docs/argocd.md) for detailed setup instructions, including
+notification configuration and how to test automated sync and rollback.

--- a/docs/argocd.md
+++ b/docs/argocd.md
@@ -1,0 +1,45 @@
+# ArgoCD Deployment Guide
+
+This project ships with example manifests for deploying the Helm chart via [ArgoCD](https://argo-cd.readthedocs.io/).
+The manifests are located in `k8s/argocd` and are organised using Kustomize.
+
+## Directory structure
+
+- `k8s/argocd/base` – base `Application` resource and notification configuration
+- `k8s/argocd/overlays/dev` – development environment overlay
+- `k8s/argocd/overlays/staging` – staging environment overlay
+- `k8s/argocd/overlays/prod` – production environment overlay
+
+Each overlay patches the base `Application` to target a different Git branch and Kubernetes namespace.
+
+## Installing ArgoCD
+
+1. Install ArgoCD on your cluster:
+   ```bash
+   kubectl create namespace argocd
+   kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+   ```
+2. Log in to the ArgoCD API server and change the admin password if desired.
+
+## Deploying the Application
+
+Apply the overlay for your environment using Kustomize:
+
+```bash
+# Deploy to the dev environment
+kubectl apply -k k8s/argocd/overlays/dev
+```
+
+The application uses an automated sync policy with pruning and self-healing enabled.
+Any changes pushed to the specified Git branch are automatically applied.
+
+## Testing Sync and Rollback
+
+1. Commit a change to the Helm chart or manifests and push to the tracked branch.
+2. ArgoCD will automatically sync the application and deploy the change.
+3. To rollback, revert the commit in Git – ArgoCD detects the change and rolls back the cluster state.
+
+## Notifications
+
+The base configuration contains an example ConfigMap for the ArgoCD [notifications controller](https://argo-cd.readthedocs.io/en/stable/operator-manual/notifications/).
+Populate the `SLACK_TOKEN` secret referenced in `notifications-cm.yaml` to receive Slack alerts when sync operations succeed or fail.

--- a/k8s/argocd/base/application.yaml
+++ b/k8s/argocd/base/application.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: airflow
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/my-org/airflow-alpine-k8s.git
+    targetRevision: main
+    path: helm
+    helm:
+      valueFiles:
+        - values-alpine.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: airflow
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/k8s/argocd/base/kustomization.yaml
+++ b/k8s/argocd/base/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - application.yaml
+  - notifications-cm.yaml

--- a/k8s/argocd/base/notifications-cm.yaml
+++ b/k8s/argocd/base/notifications-cm.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-notifications-cm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/component: notifications
+
+data:
+  service.slack: |
+    token: $SLACK_TOKEN
+  trigger.on-sync-status: |
+    - when: app.status.operationState.phase in ['Succeeded','Failed']
+      send: [slack]
+  template.sync-status: |
+    message: Application {{.app.metadata.name}} sync {{.app.status.operationState.phase}}

--- a/k8s/argocd/overlays/dev/kustomization.yaml
+++ b/k8s/argocd/overlays/dev/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - ../../base
+patchesStrategicMerge:
+  - patch.yaml

--- a/k8s/argocd/overlays/dev/patch.yaml
+++ b/k8s/argocd/overlays/dev/patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: airflow-dev
+spec:
+  source:
+    targetRevision: dev
+  destination:
+    namespace: airflow-dev

--- a/k8s/argocd/overlays/prod/kustomization.yaml
+++ b/k8s/argocd/overlays/prod/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - ../../base
+patchesStrategicMerge:
+  - patch.yaml

--- a/k8s/argocd/overlays/prod/patch.yaml
+++ b/k8s/argocd/overlays/prod/patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: airflow-prod
+spec:
+  source:
+    targetRevision: main
+  destination:
+    namespace: airflow-prod

--- a/k8s/argocd/overlays/staging/kustomization.yaml
+++ b/k8s/argocd/overlays/staging/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - ../../base
+patchesStrategicMerge:
+  - patch.yaml

--- a/k8s/argocd/overlays/staging/patch.yaml
+++ b/k8s/argocd/overlays/staging/patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: airflow-staging
+spec:
+  source:
+    targetRevision: staging
+  destination:
+    namespace: airflow-staging


### PR DESCRIPTION
## Summary
- add ArgoCD application manifests with overlays
- unignore k8s YAML files
- document ArgoCD usage and deployment

## Testing
- `./tests/test_hadolint.sh`
- `./tests/test_trivy.sh`
- `./tests/test_packages.sh`


------
https://chatgpt.com/codex/tasks/task_e_68836d86a7a8832ca7d8eb5f31fbf368