### PR TITLE
Add expanded test suite scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,18 +45,26 @@ Enable branch protection for `main` to require passing status checks and pull re
 
 ## Testing
 
-Basic validation scripts are available under `tests/`:
+Test scripts are available under `tests/`:
 
 - `test_hadolint.sh` – lint the Dockerfile with [hadolint](https://github.com/hadolint/hadolint)
 - `test_trivy.sh` – scan the Dockerfile for vulnerabilities using [Trivy](https://github.com/aquasecurity/trivy)
 - `test_packages.sh` – verify required Alpine packages are listed in the Dockerfile
+- `test_docker_build.sh` – build the Docker image and ensure Airflow starts
+- `test_k8s_integration.sh` – deploy the Helm chart on KIND and validate the cluster
+- `test_end_to_end.sh` – trigger an example DAG inside the KIND cluster
+- `test_performance.sh` – compare startup time of the Alpine image with the official image
+- `test_load.sh` – run a basic load test against the Airflow webserver
+- `test_disaster_recovery.sh` – verify pods recover if deleted
+- `test_security_compliance.sh` – check manifests with `kube-score`
 
-Run all tests with:
+Run the basic checks with:
 
 ```bash
 ./tests/test_hadolint.sh
 ./tests/test_trivy.sh
 ./tests/test_packages.sh
+./tests/test_docker_build.sh
 ```
 
 ## Kubernetes Integration Testing
@@ -70,6 +78,18 @@ Run the integration test (requires `kind`, `kubectl` and `helm` in your PATH):
 
 ```bash
 ./tests/test_k8s_integration.sh
+```
+
+### Additional Test Suites
+
+Other scripts provide broader test coverage:
+
+```bash
+./tests/test_end_to_end.sh        # run a DAG in a temporary cluster
+./tests/test_performance.sh       # compare image startup times
+./tests/test_load.sh              # apply load to the webserver
+./tests/test_disaster_recovery.sh # simulate pod failures
+./tests/test_security_compliance.sh # score manifests with kube-score
 ```
 
 ## ArgoCD Deployment

--- a/tests/test_disaster_recovery.sh
+++ b/tests/test_disaster_recovery.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+CLUSTER_NAME=${CLUSTER_NAME:-airflow-dr}
+
+for cmd in kind kubectl helm; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "$cmd command not found" >&2
+        exit 1
+    fi
+done
+
+kind create cluster --name "$CLUSTER_NAME"
+helm dependency update helm
+helm install airflow helm -n airflow --create-namespace -f helm/values-alpine.yaml
+
+kubectl wait --namespace airflow --for=condition=Ready pod -l component=scheduler --timeout=300s
+SCHED_POD=$(kubectl get pods -n airflow -l component=scheduler -o jsonpath='{.items[0].metadata.name}')
+
+# Simulate failure by deleting pod
+kubectl delete pod "$SCHED_POD" -n airflow
+kubectl wait --namespace airflow --for=condition=Ready pod -l component=scheduler --timeout=300s
+
+kind delete cluster --name "$CLUSTER_NAME"

--- a/tests/test_docker_build.sh
+++ b/tests/test_docker_build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker command not found" >&2
+    exit 1
+fi
+
+docker build -t airflow-alpine-k8s:test -f docker/Dockerfile .
+docker run --rm airflow-alpine-k8s:test airflow version

--- a/tests/test_end_to_end.sh
+++ b/tests/test_end_to_end.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+CLUSTER_NAME=${CLUSTER_NAME:-airflow-e2e}
+
+for cmd in kind kubectl helm; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "$cmd command not found" >&2
+        exit 1
+    fi
+done
+
+kind create cluster --name "$CLUSTER_NAME"
+
+helm dependency update helm
+helm install airflow helm -n airflow --create-namespace -f helm/values-alpine.yaml
+
+# Wait for scheduler pod
+kubectl wait --namespace airflow --for=condition=Ready pod -l component=scheduler --timeout=300s
+POD=$(kubectl get pods -n airflow -l component=scheduler -o jsonpath='{.items[0].metadata.name}')
+
+# Trigger a built-in example DAG and wait for completion
+kubectl exec -n airflow "$POD" -- airflow dags trigger example_bash_operator
+sleep 10
+kubectl exec -n airflow "$POD" -- airflow tasks run example_bash_operator runme_0 2021-01-01
+
+# Cleanup
+kind delete cluster --name "$CLUSTER_NAME"

--- a/tests/test_load.sh
+++ b/tests/test_load.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+CLUSTER_NAME=${CLUSTER_NAME:-airflow-load}
+
+for cmd in kind kubectl helm ab; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "$cmd command not found" >&2
+        exit 1
+    fi
+done
+
+kind create cluster --name "$CLUSTER_NAME"
+helm dependency update helm
+helm install airflow helm -n airflow --create-namespace -f helm/values-alpine.yaml
+
+kubectl wait --namespace airflow --for=condition=Ready pod -l component=webserver --timeout=300s
+WEB_POD=$(kubectl get pods -n airflow -l component=webserver -o jsonpath='{.items[0].metadata.name}')
+kubectl port-forward -n airflow "$WEB_POD" 8080:8080 &
+PORT_FWD_PID=$!
+
+sleep 10
+ab -n 100 -c 10 http://127.0.0.1:8080/ > /tmp/ab_result.txt
+kill $PORT_FWD_PID
+
+kind delete cluster --name "$CLUSTER_NAME"
+cat /tmp/ab_result.txt

--- a/tests/test_performance.sh
+++ b/tests/test_performance.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker command not found" >&2
+    exit 1
+fi
+
+# Build official image for comparison
+cat <<'DOCKERFILE' > /tmp/Dockerfile_official
+FROM apache/airflow:2.8.1
+DOCKERFILE
+
+docker build -t airflow-official:compare -f /tmp/Dockerfile_official /tmp
+
+time docker run --rm airflow-official:compare airflow info >/tmp/perf_official.txt 2>&1
+TIME_OFFICIAL=$(grep real /tmp/perf_official.txt | awk '{print $2}')
+
+docker build -t airflow-alpine-k8s:compare -f docker/Dockerfile .
+time docker run --rm airflow-alpine-k8s:compare airflow info >/tmp/perf_alpine.txt 2>&1
+TIME_ALPINE=$(grep real /tmp/perf_alpine.txt | awk '{print $2}')
+
+echo "official_image_time=$TIME_OFFICIAL" 
+echo "alpine_image_time=$TIME_ALPINE"
+

--- a/tests/test_security_compliance.sh
+++ b/tests/test_security_compliance.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+if ! command -v kube-score >/dev/null 2>&1; then
+    echo "kube-score command not found" >&2
+    exit 1
+fi
+
+find k8s -name '*.yaml' -print0 | xargs -0 kube-score score


### PR DESCRIPTION
## Summary
- add new testing scripts for Docker, Kubernetes, end-to-end, performance, load, DR and security checks
- describe all available tests in README

## Testing
- `./tests/test_hadolint.sh` *(fails: hadolint command not found)*
- `./tests/test_trivy.sh` *(fails: trivy command not found)*
- `./tests/test_packages.sh`
- `./tests/test_docker_build.sh` *(fails: Docker daemon not running)*
- `./tests/test_k8s_integration.sh` *(fails: kind command not found)*
- `./tests/test_end_to_end.sh` *(fails: kind command not found)*
- `./tests/test_performance.sh` *(fails: Docker daemon not running)*
- `./tests/test_load.sh` *(fails: kind command not found)*
- `./tests/test_disaster_recovery.sh` *(fails: kind command not found)*
- `./tests/test_security_compliance.sh` *(fails: kube-score command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688394b378f0832c880e8fd9e5cd7ca5