### PR TITLE
Implement dedicated Airflow user

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Test scripts in the `tests/` directory cover linting, vulnerability scanning and
 ./tests/test_trivy.sh
 ./tests/test_packages.sh
 ./tests/test_docker_build.sh
+./tests/test_user_permissions.sh
 ```
 
 The security-related tests expect `hadolint`, `trivy`, `cosign` and `kube-score` to be installed.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,15 +26,18 @@ RUN apk add --no-cache --virtual .build-deps \
 FROM python:${PYTHON_VERSION}-alpine${ALPINE_VERSION}
 ARG AIRFLOW_VERSION
 ARG PYTHON_VERSION
+ARG AIRFLOW_UID=50000
+ARG AIRFLOW_GID=50000
 ENV AIRFLOW_HOME=/opt/airflow \
     PATH=/usr/local/bin:$PATH
 
 # Runtime dependencies and user setup
 # hadolint ignore=DL3018
 RUN apk add --no-cache bash postgresql-client redis su-exec re2 \
-    && addgroup -S airflow && adduser -S -G airflow airflow \
-    && mkdir -p ${AIRFLOW_HOME} \
-    && chown airflow:airflow ${AIRFLOW_HOME}
+    && addgroup -S -g ${AIRFLOW_GID} airflow \
+    && adduser -S -u ${AIRFLOW_UID} -G airflow -h ${AIRFLOW_HOME} airflow \
+    && mkdir -p ${AIRFLOW_HOME}/dags ${AIRFLOW_HOME}/logs ${AIRFLOW_HOME}/plugins \
+    && chown -R airflow:airflow ${AIRFLOW_HOME}
 
 COPY --from=builder /usr/local /usr/local
 COPY docker/entrypoint.sh /entrypoint.sh

--- a/docs/security.md
+++ b/docs/security.md
@@ -30,6 +30,13 @@ Consider applying Kubernetes NetworkPolicies to restrict pod-to-pod communicatio
 ## RBAC
 The example manifests use minimal RBAC permissions. Review the roles and tighten them to follow the principle of least privilege.
 
+## Non-Root Containers
+The Docker images define a dedicated `airflow` user (UID/GID `50000`) with a home
+directory at `/opt/airflow`. Running Airflow as a non-root user improves
+container security and works well with Kubernetes security contexts. The
+`tests/test_user_permissions.sh` script verifies that the image uses the correct
+UID/GID and file permissions.
+
 ## Updates
 Monitor Airflow and dependency release notes for security patches. Rebuild and redeploy the image when vulnerabilities are fixed.
 

--- a/tests/test_user_permissions.sh
+++ b/tests/test_user_permissions.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+    echo "docker not available, skipping user permissions test" >&2
+    exit 0
+fi
+
+IMAGE=airflow-alpine-k8s:user-test
+
+docker build -t "$IMAGE" -f docker/Dockerfile .
+uid=$(docker run --rm "$IMAGE" id -u)
+gid=$(docker run --rm "$IMAGE" id -g)
+home=$(docker run --rm "$IMAGE" sh -c 'echo "$HOME"')
+
+if [ "$uid" != "50000" ] || [ "$gid" != "50000" ]; then
+    echo "Expected UID/GID 50000, got ${uid}:${gid}" >&2
+    exit 1
+fi
+
+if [ "$home" != "/opt/airflow" ]; then
+    echo "Expected home directory /opt/airflow" >&2
+    exit 1
+fi
+
+perms=$(docker run --rm "$IMAGE" sh -c "stat -c '%u:%g' /opt/airflow")
+if [ "$perms" != "50000:50000" ]; then
+    echo "Incorrect permissions on /opt/airflow" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- add UID/GID options and set up Airflow home dirs in Dockerfile
- add user permissions test
- document new test and non-root user details

## Testing
- `./tests/test_hadolint.sh` *(fails: hadolint command not found)*
- `./tests/test_trivy.sh` *(skipped: trivy not available)*
- `./tests/test_packages.sh`
- `./tests/test_docker_build.sh` *(skipped: docker not available)*
- `./tests/test_user_permissions.sh` *(skipped: docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_6886f0196b64832cb67b4379aa112bbe