### PR TITLE
Implement dedicated Airflow user

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A lightweight Apache Airflow distribution built on Alpine Linux and tailored for
 3. Optionally deploy via ArgoCD (see [docs/argocd.md](docs/argocd.md)).
 
 ## Docker Image
-The Docker image is based on Alpine and contains just the packages required to run Airflow. See [docs/docker-build.md](docs/docker-build.md) for details on customizing the build and for a list of installed packages.
+The Docker image is based on Alpine and contains just the packages required to run Airflow. It runs as a non-root `airflow` user (UID/GID 50000) and installs Python packages under `/opt/airflow/.local`. See [docs/docker-build.md](docs/docker-build.md) for details on customizing the build and for a list of installed packages.
 
 ## Helm Chart
 The chart in `helm/` wraps the official Airflow chart and replaces the image with the Alpine variant. Configuration options are documented in [docs/helm-customization.md](docs/helm-customization.md).
@@ -66,6 +66,7 @@ Test scripts in the `tests/` directory cover linting, vulnerability scanning and
 ./tests/test_trivy.sh
 ./tests/test_packages.sh
 ./tests/test_docker_build.sh
+./tests/test_user_permissions.sh
 ```
 
 The security-related tests expect `hadolint`, `trivy`, `cosign` and `kube-score` to be installed.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,39 +6,56 @@ ARG ALPINE_VERSION=3.21
 FROM python:${PYTHON_VERSION}-alpine${ALPINE_VERSION} AS builder
 ARG AIRFLOW_VERSION
 ARG PYTHON_VERSION
+ARG AIRFLOW_UID=50000
+ARG AIRFLOW_GID=50000
 
-ENV PIP_NO_CACHE_DIR=1
+ENV AIRFLOW_HOME=/opt/airflow \
+    PIP_NO_CACHE_DIR=1 \
+    PATH=${AIRFLOW_HOME}/.local/bin:$PATH
 
 # Install build dependencies
 # hadolint ignore=DL3018,DL3013
 RUN apk add --no-cache --virtual .build-deps \
         gcc g++ musl-dev libc-dev libffi-dev openssl-dev cargo make postgresql-dev \
         py3-pybind11-dev re2-dev \
-    && pip install --upgrade pip \
-    && pip install "apache-airflow==${AIRFLOW_VERSION}" \
+    && addgroup -S -g ${AIRFLOW_GID} airflow \
+    && adduser -S -u ${AIRFLOW_UID} -G airflow -h ${AIRFLOW_HOME} airflow \
+    && mkdir -p ${AIRFLOW_HOME} \
+    && chown -R airflow:airflow ${AIRFLOW_HOME}
+
+USER airflow
+RUN pip install --upgrade --user pip \
+    && pip install --user "apache-airflow==${AIRFLOW_VERSION}" \
          --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt" \
-    && pip install --no-cache-dir --upgrade \
+    && pip install --user --no-cache-dir --upgrade \
          "Werkzeug>=3.0.6" \
          "cryptography>=44.0.1" \
-         "starlette>=0.47.2" \
-    && apk del .build-deps
+         "starlette>=0.47.2"
+
+USER root
+RUN apk del .build-deps
 
 FROM python:${PYTHON_VERSION}-alpine${ALPINE_VERSION}
 ARG AIRFLOW_VERSION
 ARG PYTHON_VERSION
+ARG AIRFLOW_UID=50000
+ARG AIRFLOW_GID=50000
 ENV AIRFLOW_HOME=/opt/airflow \
-    PATH=/usr/local/bin:$PATH
+    PATH=${AIRFLOW_HOME}/.local/bin:/usr/local/bin:$PATH
 
 # Runtime dependencies and user setup
 # hadolint ignore=DL3018
 RUN apk add --no-cache bash postgresql-client redis su-exec re2 \
-    && addgroup -S airflow && adduser -S -G airflow airflow \
-    && mkdir -p ${AIRFLOW_HOME} \
-    && chown airflow:airflow ${AIRFLOW_HOME}
+    && addgroup -S -g ${AIRFLOW_GID} airflow \
+    && adduser -S -u ${AIRFLOW_UID} -G airflow -h ${AIRFLOW_HOME} airflow \
+    && mkdir -p ${AIRFLOW_HOME}/dags ${AIRFLOW_HOME}/logs ${AIRFLOW_HOME}/plugins \
+    && chown -R airflow:airflow ${AIRFLOW_HOME}
 
 COPY --from=builder /usr/local /usr/local
+COPY --from=builder ${AIRFLOW_HOME}/.local ${AIRFLOW_HOME}/.local
 COPY docker/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN chown -R airflow:airflow ${AIRFLOW_HOME} \
+    && chmod +x /entrypoint.sh
 
 USER airflow
 WORKDIR ${AIRFLOW_HOME}

--- a/docs/docker-build.md
+++ b/docs/docker-build.md
@@ -13,6 +13,10 @@ docker build -t airflow-alpine -f docker/Dockerfile .
 ```
 The Dockerfile installs the minimal set of Alpine packages required for Airflow. The resulting image is around 200MB.
 
+All Python packages are installed using a dedicated `airflow` user so no system
+directories are modified during the build. You can extend the image by copying
+additional Python dependencies into `/opt/airflow/.local`.
+
 ## Customising
 You can extend the image by creating your own Dockerfile that starts with `FROM airflow-alpine` and installs additional system packages or Python dependencies.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -30,6 +30,15 @@ Consider applying Kubernetes NetworkPolicies to restrict pod-to-pod communicatio
 ## RBAC
 The example manifests use minimal RBAC permissions. Review the roles and tighten them to follow the principle of least privilege.
 
+## Non-Root Containers
+The Docker images define a dedicated `airflow` user (UID/GID `50000`) with a home
+directory at `/opt/airflow`. Running Airflow as a non-root user improves
+container security and works well with Kubernetes security contexts. The
+`tests/test_user_permissions.sh` script verifies that the image uses the correct
+UID/GID and file permissions.
+All Python packages are installed under `/opt/airflow/.local` by this user to
+avoid modifying system directories.
+
 ## Updates
 Monitor Airflow and dependency release notes for security patches. Rebuild and redeploy the image when vulnerabilities are fixed.
 

--- a/tests/test_user_permissions.sh
+++ b/tests/test_user_permissions.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+    echo "docker not available, skipping user permissions test" >&2
+    exit 0
+fi
+
+IMAGE=airflow-alpine-k8s:user-test
+
+docker build -t "$IMAGE" -f docker/Dockerfile .
+uid=$(docker run --rm "$IMAGE" id -u)
+gid=$(docker run --rm "$IMAGE" id -g)
+home=$(docker run --rm "$IMAGE" sh -c 'echo "$HOME"')
+
+if [ "$uid" != "50000" ] || [ "$gid" != "50000" ]; then
+    echo "Expected UID/GID 50000, got ${uid}:${gid}" >&2
+    exit 1
+fi
+
+if [ "$home" != "/opt/airflow" ]; then
+    echo "Expected home directory /opt/airflow" >&2
+    exit 1
+fi
+
+perms=$(docker run --rm "$IMAGE" sh -c "stat -c '%u:%g' /opt/airflow")
+if [ "$perms" != "50000:50000" ]; then
+    echo "Incorrect permissions on /opt/airflow" >&2
+    exit 1
+fi
+
+pkgperms=$(docker run --rm "$IMAGE" sh -c "stat -c '%u:%g' /opt/airflow/.local")
+if [ "$pkgperms" != "50000:50000" ]; then
+    echo "Incorrect permissions on /opt/airflow/.local" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- add UID/GID options and set up Airflow home dirs in Dockerfile
- add user permissions test
- document new test and non-root user details
- run pip installs as dedicated user

## Testing
- `./tests/test_hadolint.sh` *(fails: hadolint command not found)*
- `./tests/test_trivy.sh` *(skipped: trivy not available)*
- `./tests/test_packages.sh`
- `./tests/test_docker_build.sh` *(skipped: docker not available)*
- `./tests/test_user_permissions.sh` *(skipped: docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_6886f0196b64832cb67b4379aa112bbe